### PR TITLE
bump dev-sass

### DIFF
--- a/maxmobility/apps/eval-mobile/package.json
+++ b/maxmobility/apps/eval-mobile/package.json
@@ -90,7 +90,7 @@
     "css-loader": "~0.28.7",
     "extract-text-webpack-plugin": "~3.0.2",
     "lazy": "1.0.11",
-    "nativescript-dev-sass": "~1.3.6",
+    "nativescript-dev-sass": "~1.5.0",
     "nativescript-dev-typescript": "~0.6.0",
     "nativescript-dev-webpack": "~0.9.1",
     "nativescript-worker-loader": "~0.8.1",


### PR DESCRIPTION
Bumps the `nativescript-dev-sass` dep version which should stabilize the `node-sass` compilation issues during livesync.